### PR TITLE
[#25] Setup localization

### DIFF
--- a/l10n.yaml
+++ b/l10n.yaml
@@ -1,0 +1,3 @@
+arb-dir: lib/l10n
+template-arb-file: app_en.arb
+output-localization-file: app_localizations.dart

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,6 +1,6 @@
 {
-  "buttonLogin": "Login",
-  "@buttonLogin": {
-    "description": "Login button text"
-  }
+  "loginEmail": "Email",
+  "loginPassword": "Password",
+  "loginForgot": "Forgot?",
+  "loginText": "Log In"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,0 +1,6 @@
+{
+  "buttonLogin": "Login",
+  "@buttonLogin": {
+    "description": "Login button text"
+  }
+}

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -1,3 +1,6 @@
 {
-  "buttonLogin": "Đăng nhập"
+  "loginEmail": "Email",
+  "loginPassword": "Mật khẩu",
+  "loginForgot": "Quên?",
+  "loginText": "Đăng nhập"
 }

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -1,0 +1,3 @@
+{
+  "buttonLogin": "Đăng nhập"
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_config/flutter_config.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_survey/pages/login_page.dart';
 import 'package:flutter_survey/resouces/app_theme.dart';
@@ -17,6 +18,7 @@ class MyApp extends StatelessWidget {
       theme: AppTheme.light,
       home: LoginPage(),
       localizationsDelegates: [
+        AppLocalizations.delegate,
         GlobalMaterialLocalizations.delegate,
         GlobalWidgetsLocalizations.delegate,
         GlobalCupertinoLocalizations.delegate,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_config/flutter_config.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_survey/pages/login_page.dart';
 import 'package:flutter_survey/resouces/app_theme.dart';
 
@@ -17,16 +16,8 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       theme: AppTheme.light,
       home: LoginPage(),
-      localizationsDelegates: [
-        AppLocalizations.delegate,
-        GlobalMaterialLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
-      ],
-      supportedLocales: [
-        Locale('en', ''),
-        Locale('vi', ''),
-      ],
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_config/flutter_config.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_survey/pages/login_page.dart';
 import 'package:flutter_survey/resouces/app_theme.dart';
 
@@ -15,6 +16,15 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       theme: AppTheme.light,
       home: LoginPage(),
+      localizationsDelegates: [
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: [
+        Locale('en', ''),
+        Locale('vi', ''),
+      ],
     );
   }
 }

--- a/lib/pages/login_page.dart
+++ b/lib/pages/login_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_survey/gen/assets.gen.dart';
 import 'package:flutter_survey/gen/colors.gen.dart';
 import 'package:flutter_survey/resouces/dimens.dart';
@@ -50,8 +51,10 @@ class LoginPage extends StatelessWidget {
       children: [
         TextField(
           autofocus: true,
-          // TODO localization https://github.com/luongvo/flutter-survey/issues/25
-          decoration: _formInputDecoration(context, "Email"),
+          decoration: _formInputDecoration(
+            context,
+            AppLocalizations.of(context)!.loginEmail,
+          ),
           keyboardType: TextInputType.emailAddress,
           style: Theme.of(context).textTheme.bodyText1,
           textInputAction: TextInputAction.next,
@@ -62,7 +65,10 @@ class LoginPage extends StatelessWidget {
         Stack(
           children: [
             TextField(
-              decoration: _formInputDecoration(context, "Password").copyWith(
+              decoration: _formInputDecoration(
+                context,
+                AppLocalizations.of(context)!.loginPassword,
+              ).copyWith(
                 contentPadding: EdgeInsets.symmetric(
                   horizontal: Dimens.inputHorizontalPadding,
                   vertical: Dimens.inputVerticalPadding,
@@ -82,7 +88,7 @@ class LoginPage extends StatelessWidget {
                   height: double.infinity,
                   child: TextButton(
                     child: Text(
-                      "Forgot?",
+                      AppLocalizations.of(context)!.loginForgot,
                       style: Theme.of(context).textTheme.bodyText2!.copyWith(
                             color: ColorName.whiteAlpha50,
                           ),
@@ -118,7 +124,7 @@ class LoginPage extends StatelessWidget {
                 Theme.of(context).textTheme.button,
               ),
             ),
-            child: Text('Log in'),
+            child: Text(AppLocalizations.of(context)!.loginText),
             onPressed: () {
               // TODO login https://github.com/luongvo/flutter-survey/issues/7
             },

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -237,6 +237,11 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.1"
+  flutter_localizations:
+    dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_svg:
     dependency: "direct main"
     description:
@@ -296,6 +301,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.0.0"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.17.0"
   io:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.0.0+1
+version: 0.2.0+1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,9 @@ dependencies:
   flutter:
     sdk: flutter
 
+  flutter_localizations:
+    sdk: flutter
+  intl: ^0.17.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
@@ -43,6 +46,7 @@ dev_dependencies:
 
 # The following section is specific to Flutter.
 flutter:
+  generate: true
 
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -16,7 +16,7 @@ void main() {
     // Verify that our counter starts at 0.
     expect(find.text('Email'), findsOneWidget);
     expect(find.text('Password'), findsOneWidget);
-    expect(find.text('Log in'), findsOneWidget);
+    expect(find.text('Log In'), findsOneWidget);
     expect(find.text('Forgot?'), findsOneWidget);
   });
 }


### PR DESCRIPTION
https://github.com/luongvo/flutter-survey/issues/25

## What happened 👀

We need to support multi-languages due to can increase our user base.
 
## Insight 📝

- Follow the guide from https://flutter.dev/docs/development/accessibility-and-localization/internationalization to setup i18n.
- Add support to have `en` and `vi` translations. 
 
## Proof Of Work 📹

- EN
<img src="https://user-images.githubusercontent.com/16315358/132958262-5c913540-35f8-4223-be74-086fb9b54eb6.png" width=300 />


- VI


<img src="https://user-images.githubusercontent.com/16315358/132958258-16174534-8ae4-4d5a-a5f7-a757df190171.png" width=300 />
