### PR TITLE
[#6] [Backend] As a user, I can log in to the app

### DIFF
--- a/lib/api/oauth_service.dart
+++ b/lib/api/oauth_service.dart
@@ -7,11 +7,11 @@ import 'package:retrofit/retrofit.dart';
 part 'oauth_service.g.dart';
 
 @RestApi()
-abstract class OauthService {
-  factory OauthService(Dio dio, {String baseUrl}) = _OauthService;
+abstract class OAuthService {
+  factory OAuthService(Dio dio, {String baseUrl}) = _OAuthService;
 
   @POST('/v1/oauth/token')
-  Future<BaseHttpResponse<OauthTokenResponse>> login(
-    @Body() OauthTokenRequest body,
+  Future<BaseHttpResponse<OAuthTokenResponse>> login(
+    @Body() OAuthTokenRequest body,
   );
 }

--- a/lib/api/oauth_service.dart
+++ b/lib/api/oauth_service.dart
@@ -1,4 +1,7 @@
 import 'package:dio/dio.dart';
+import 'package:flutter_survey/api/request/oauth_token_request.dart';
+import 'package:flutter_survey/api/response/base/base_http_response.dart';
+import 'package:flutter_survey/api/response/oauth_token_response.dart';
 import 'package:retrofit/retrofit.dart';
 
 part 'oauth_service.g.dart';
@@ -6,4 +9,9 @@ part 'oauth_service.g.dart';
 @RestApi()
 abstract class OauthService {
   factory OauthService(Dio dio, {String baseUrl}) = _OauthService;
+
+  @POST('/v1/oauth/token')
+  Future<BaseHttpResponse<OauthTokenResponse>> login(
+    @Body() OauthTokenRequest body,
+  );
 }

--- a/lib/api/oauth_service.g.dart
+++ b/lib/api/oauth_service.g.dart
@@ -13,6 +13,22 @@ class _OauthService implements OauthService {
 
   String? baseUrl;
 
+  @override
+  Future<BaseHttpResponse<OauthTokenResponse>> login(body) async {
+    const _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _data = <String, dynamic>{};
+    _data.addAll(body.toJson());
+    final _result = await _dio.fetch<Map<String, dynamic>>(
+        _setStreamType<BaseHttpResponse<OauthTokenResponse>>(
+            Options(method: 'POST', headers: <String, dynamic>{}, extra: _extra)
+                .compose(_dio.options, '/v1/oauth/token',
+                    queryParameters: queryParameters, data: _data)
+                .copyWith(baseUrl: baseUrl ?? _dio.options.baseUrl)));
+    final value = BaseHttpResponse<OauthTokenResponse>.fromJson(_result.data!);
+    return value;
+  }
+
   RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
     if (T != dynamic &&
         !(requestOptions.responseType == ResponseType.bytes ||

--- a/lib/api/oauth_service.g.dart
+++ b/lib/api/oauth_service.g.dart
@@ -6,26 +6,26 @@ part of 'oauth_service.dart';
 // RetrofitGenerator
 // **************************************************************************
 
-class _OauthService implements OauthService {
-  _OauthService(this._dio, {this.baseUrl});
+class _OAuthService implements OAuthService {
+  _OAuthService(this._dio, {this.baseUrl});
 
   final Dio _dio;
 
   String? baseUrl;
 
   @override
-  Future<BaseHttpResponse<OauthTokenResponse>> login(body) async {
+  Future<BaseHttpResponse<OAuthTokenResponse>> login(body) async {
     const _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final _data = <String, dynamic>{};
     _data.addAll(body.toJson());
     final _result = await _dio.fetch<Map<String, dynamic>>(
-        _setStreamType<BaseHttpResponse<OauthTokenResponse>>(
+        _setStreamType<BaseHttpResponse<OAuthTokenResponse>>(
             Options(method: 'POST', headers: <String, dynamic>{}, extra: _extra)
                 .compose(_dio.options, '/v1/oauth/token',
                     queryParameters: queryParameters, data: _data)
                 .copyWith(baseUrl: baseUrl ?? _dio.options.baseUrl)));
-    final value = BaseHttpResponse<OauthTokenResponse>.fromJson(_result.data!);
+    final value = BaseHttpResponse<OAuthTokenResponse>.fromJson(_result.data!);
     return value;
   }
 

--- a/lib/api/repository/oauth_repository.dart
+++ b/lib/api/repository/oauth_repository.dart
@@ -5,18 +5,18 @@ import 'package:flutter_survey/env.dart';
 import 'package:flutter_survey/models/oauth_token.dart';
 import 'package:injectable/injectable.dart';
 
-abstract class OauthRepository {
+abstract class OAuthRepository {
   Future<OAuthToken> login({
     required String email,
     required String password,
   });
 }
 
-@Singleton(as: OauthRepository)
-class OauthRepositoryImpl extends OauthRepository {
-  late OauthService _oauthService;
+@Singleton(as: OAuthRepository)
+class OAuthRepositoryImpl extends OAuthRepository {
+  late OAuthService _oauthService;
 
-  OauthRepositoryImpl(this._oauthService);
+  OAuthRepositoryImpl(this._oauthService);
 
   @override
   Future<OAuthToken> login({
@@ -25,7 +25,7 @@ class OauthRepositoryImpl extends OauthRepository {
   }) async {
     try {
       final response = await _oauthService
-          .login(OauthTokenRequest(
+          .login(OAuthTokenRequest(
             email: email,
             password: password,
             clientId: Env.basicAuthClientId,

--- a/lib/api/repository/oauth_repository.dart
+++ b/lib/api/repository/oauth_repository.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_survey/api/oauth_service.dart';
+import 'package:flutter_survey/api/request/oauth_token_request.dart';
+import 'package:flutter_survey/api/response/oauth_token_response.dart';
+import 'package:flutter_survey/env.dart';
+import 'package:injectable/injectable.dart';
+
+abstract class OauthRepository {
+  Future<OauthTokenResponse> login({
+    required String email,
+    required String password,
+  });
+}
+
+@Singleton(as: OauthRepository)
+class OauthRepositoryImpl extends OauthRepository {
+  late OauthService _oauthService;
+
+  OauthRepositoryImpl(this._oauthService);
+
+  @override
+  Future<OauthTokenResponse> login({
+    required String email,
+    required String password,
+  }) {
+    return _oauthService
+        .login(OauthTokenRequest(
+          email: email,
+          password: password,
+          clientId: Env.basicAuthClientId,
+          clientSecret: Env.basicAuthClientSecret,
+        ))
+        .then((response) => response.data.attributes);
+  }
+}

--- a/lib/api/repository/oauth_repository.dart
+++ b/lib/api/repository/oauth_repository.dart
@@ -1,11 +1,12 @@
+import 'package:flutter_survey/api/exception/network_exceptions.dart';
 import 'package:flutter_survey/api/oauth_service.dart';
 import 'package:flutter_survey/api/request/oauth_token_request.dart';
-import 'package:flutter_survey/api/response/oauth_token_response.dart';
 import 'package:flutter_survey/env.dart';
+import 'package:flutter_survey/models/oauth_token.dart';
 import 'package:injectable/injectable.dart';
 
 abstract class OauthRepository {
-  Future<OauthTokenResponse> login({
+  Future<OAuthToken> login({
     required String email,
     required String password,
   });
@@ -18,17 +19,27 @@ class OauthRepositoryImpl extends OauthRepository {
   OauthRepositoryImpl(this._oauthService);
 
   @override
-  Future<OauthTokenResponse> login({
+  Future<OAuthToken> login({
     required String email,
     required String password,
-  }) {
-    return _oauthService
-        .login(OauthTokenRequest(
-          email: email,
-          password: password,
-          clientId: Env.basicAuthClientId,
-          clientSecret: Env.basicAuthClientSecret,
-        ))
-        .then((response) => response.data.attributes);
+  }) async {
+    try {
+      final response = await _oauthService
+          .login(OauthTokenRequest(
+            email: email,
+            password: password,
+            clientId: Env.basicAuthClientId,
+            clientSecret: Env.basicAuthClientSecret,
+          ))
+          .then((response) => response.data.attributes);
+      return OAuthToken(
+        accessToken: response.accessToken,
+        refreshToken: response.refreshToken,
+        tokenType: response.tokenType,
+        expiresIn: response.expiresIn,
+      );
+    } catch (exception) {
+      throw NetworkExceptions.fromDioException(exception);
+    }
   }
 }

--- a/lib/api/request/oauth_token_request.dart
+++ b/lib/api/request/oauth_token_request.dart
@@ -5,7 +5,7 @@ part 'oauth_token_request.g.dart';
 const String GRANT_TYPE_PASSWORD = "password";
 
 @JsonSerializable()
-class OauthTokenRequest {
+class OAuthTokenRequest {
   @JsonKey(name: 'grant_type')
   String grantType;
   @JsonKey(name: 'email')
@@ -17,7 +17,7 @@ class OauthTokenRequest {
   @JsonKey(name: 'client_secret')
   String clientSecret;
 
-  OauthTokenRequest({
+  OAuthTokenRequest({
     this.grantType = GRANT_TYPE_PASSWORD,
     required this.email,
     required this.password,
@@ -25,8 +25,8 @@ class OauthTokenRequest {
     required this.clientSecret,
   });
 
-  factory OauthTokenRequest.fromJson(Map<String, dynamic> json) =>
-      _$OauthTokenRequestFromJson(json);
+  factory OAuthTokenRequest.fromJson(Map<String, dynamic> json) =>
+      _$OAuthTokenRequestFromJson(json);
 
-  Map<String, dynamic> toJson() => _$OauthTokenRequestToJson(this);
+  Map<String, dynamic> toJson() => _$OAuthTokenRequestToJson(this);
 }

--- a/lib/api/request/oauth_token_request.dart
+++ b/lib/api/request/oauth_token_request.dart
@@ -1,0 +1,32 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'oauth_token_request.g.dart';
+
+const String GRANT_TYPE_PASSWORD = "password";
+
+@JsonSerializable()
+class OauthTokenRequest {
+  @JsonKey(name: 'grant_type')
+  String grantType;
+  @JsonKey(name: 'email')
+  String email;
+  @JsonKey(name: 'password')
+  String password;
+  @JsonKey(name: 'client_id')
+  String clientId;
+  @JsonKey(name: 'client_secret')
+  String clientSecret;
+
+  OauthTokenRequest({
+    this.grantType = GRANT_TYPE_PASSWORD,
+    required this.email,
+    required this.password,
+    required this.clientId,
+    required this.clientSecret,
+  });
+
+  factory OauthTokenRequest.fromJson(Map<String, dynamic> json) =>
+      _$OauthTokenRequestFromJson(json);
+
+  Map<String, dynamic> toJson() => _$OauthTokenRequestToJson(this);
+}

--- a/lib/api/request/oauth_token_request.g.dart
+++ b/lib/api/request/oauth_token_request.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'oauth_token_request.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+OauthTokenRequest _$OauthTokenRequestFromJson(Map<String, dynamic> json) {
+  return OauthTokenRequest(
+    grantType: json['grant_type'] as String,
+    email: json['email'] as String,
+    password: json['password'] as String,
+    clientId: json['client_id'] as String,
+    clientSecret: json['client_secret'] as String,
+  );
+}
+
+Map<String, dynamic> _$OauthTokenRequestToJson(OauthTokenRequest instance) =>
+    <String, dynamic>{
+      'grant_type': instance.grantType,
+      'email': instance.email,
+      'password': instance.password,
+      'client_id': instance.clientId,
+      'client_secret': instance.clientSecret,
+    };

--- a/lib/api/request/oauth_token_request.g.dart
+++ b/lib/api/request/oauth_token_request.g.dart
@@ -6,8 +6,8 @@ part of 'oauth_token_request.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-OauthTokenRequest _$OauthTokenRequestFromJson(Map<String, dynamic> json) {
-  return OauthTokenRequest(
+OAuthTokenRequest _$OAuthTokenRequestFromJson(Map<String, dynamic> json) {
+  return OAuthTokenRequest(
     grantType: json['grant_type'] as String,
     email: json['email'] as String,
     password: json['password'] as String,
@@ -16,7 +16,7 @@ OauthTokenRequest _$OauthTokenRequestFromJson(Map<String, dynamic> json) {
   );
 }
 
-Map<String, dynamic> _$OauthTokenRequestToJson(OauthTokenRequest instance) =>
+Map<String, dynamic> _$OAuthTokenRequestToJson(OAuthTokenRequest instance) =>
     <String, dynamic>{
       'grant_type': instance.grantType,
       'email': instance.email,

--- a/lib/api/response/base/api_response.dart
+++ b/lib/api/response/base/api_response.dart
@@ -19,16 +19,16 @@ class ApiResponse<T extends BaseResponse> {
   Map<String, dynamic> toJson() => _$ApiResponseToJson(this);
 
   static T _dataFromJson<T>(Map<String, dynamic> json) {
-    if (T == OauthTokenResponse) {
-      return OauthTokenResponse.fromJson(json) as T;
+    if (T == OAuthTokenResponse) {
+      return OAuthTokenResponse.fromJson(json) as T;
     } else {
       throw Exception("_dataFromJson Not supported response type");
     }
   }
 
   static Map<String, dynamic> _dataToJson<T>(T value) {
-    if (T is OauthTokenResponse) {
-      return (T as OauthTokenResponse).toJson();
+    if (T is OAuthTokenResponse) {
+      return (T as OAuthTokenResponse).toJson();
     } else {
       throw Exception("_dataToJson Not supported response type");
     }

--- a/lib/api/response/base/api_response.dart
+++ b/lib/api/response/base/api_response.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_survey/api/response/base/base_http_response.dart';
+import 'package:flutter_survey/api/response/oauth_token_response.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'api_response.g.dart';
@@ -18,10 +19,18 @@ class ApiResponse<T extends BaseResponse> {
   Map<String, dynamic> toJson() => _$ApiResponseToJson(this);
 
   static T _dataFromJson<T>(Map<String, dynamic> json) {
-    throw Exception("_dataFromJson Not supported response type");
+    if (T == OauthTokenResponse) {
+      return OauthTokenResponse.fromJson(json) as T;
+    } else {
+      throw Exception("_dataFromJson Not supported response type");
+    }
   }
 
   static Map<String, dynamic> _dataToJson<T>(T value) {
-    throw Exception("_dataToJson Not supported response type");
+    if (T is OauthTokenResponse) {
+      return (T as OauthTokenResponse).toJson();
+    } else {
+      throw Exception("_dataToJson Not supported response type");
+    }
   }
 }

--- a/lib/api/response/oauth_token_response.dart
+++ b/lib/api/response/oauth_token_response.dart
@@ -4,7 +4,7 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 part 'oauth_token_response.g.dart';
 
 @JsonSerializable()
-class OauthTokenResponse extends BaseResponse {
+class OAuthTokenResponse extends BaseResponse {
   @JsonKey(name: "access_token")
   String accessToken;
   @JsonKey(name: "token_type")
@@ -16,7 +16,7 @@ class OauthTokenResponse extends BaseResponse {
   @JsonKey(name: "created_at")
   int createdAt;
 
-  OauthTokenResponse({
+  OAuthTokenResponse({
     required this.accessToken,
     required this.tokenType,
     required this.expiresIn,
@@ -24,8 +24,8 @@ class OauthTokenResponse extends BaseResponse {
     required this.createdAt,
   });
 
-  factory OauthTokenResponse.fromJson(Map<String, dynamic> json) =>
-      _$OauthTokenResponseFromJson(json);
+  factory OAuthTokenResponse.fromJson(Map<String, dynamic> json) =>
+      _$OAuthTokenResponseFromJson(json);
 
-  Map<String, dynamic> toJson() => _$OauthTokenResponseToJson(this);
+  Map<String, dynamic> toJson() => _$OAuthTokenResponseToJson(this);
 }

--- a/lib/api/response/oauth_token_response.dart
+++ b/lib/api/response/oauth_token_response.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_survey/api/response/base/base_http_response.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'oauth_token_response.g.dart';
+
+@JsonSerializable()
+class OauthTokenResponse extends BaseResponse {
+  @JsonKey(name: "access_token")
+  String? accessToken;
+  @JsonKey(name: "token_type")
+  String? tokenType;
+  @JsonKey(name: "expires_in")
+  double? expiresIn;
+  @JsonKey(name: "refresh_token")
+  String? refreshToken;
+  @JsonKey(name: "created_at")
+  double? createdAt;
+
+  OauthTokenResponse({
+    required this.accessToken,
+    required this.tokenType,
+    required this.expiresIn,
+    required this.refreshToken,
+    required this.createdAt,
+  });
+
+  factory OauthTokenResponse.fromJson(Map<String, dynamic> json) =>
+      _$OauthTokenResponseFromJson(json);
+
+  Map<String, dynamic> toJson() => _$OauthTokenResponseToJson(this);
+}

--- a/lib/api/response/oauth_token_response.dart
+++ b/lib/api/response/oauth_token_response.dart
@@ -6,15 +6,15 @@ part 'oauth_token_response.g.dart';
 @JsonSerializable()
 class OauthTokenResponse extends BaseResponse {
   @JsonKey(name: "access_token")
-  String? accessToken;
+  String accessToken;
   @JsonKey(name: "token_type")
-  String? tokenType;
+  String tokenType;
   @JsonKey(name: "expires_in")
-  double? expiresIn;
+  int expiresIn;
   @JsonKey(name: "refresh_token")
-  String? refreshToken;
+  String refreshToken;
   @JsonKey(name: "created_at")
-  double? createdAt;
+  int createdAt;
 
   OauthTokenResponse({
     required this.accessToken,

--- a/lib/api/response/oauth_token_response.g.dart
+++ b/lib/api/response/oauth_token_response.g.dart
@@ -6,8 +6,8 @@ part of 'oauth_token_response.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-OauthTokenResponse _$OauthTokenResponseFromJson(Map<String, dynamic> json) {
-  return OauthTokenResponse(
+OAuthTokenResponse _$OAuthTokenResponseFromJson(Map<String, dynamic> json) {
+  return OAuthTokenResponse(
     accessToken: json['access_token'] as String,
     tokenType: json['token_type'] as String,
     expiresIn: json['expires_in'] as int,
@@ -16,7 +16,7 @@ OauthTokenResponse _$OauthTokenResponseFromJson(Map<String, dynamic> json) {
   );
 }
 
-Map<String, dynamic> _$OauthTokenResponseToJson(OauthTokenResponse instance) =>
+Map<String, dynamic> _$OAuthTokenResponseToJson(OAuthTokenResponse instance) =>
     <String, dynamic>{
       'access_token': instance.accessToken,
       'token_type': instance.tokenType,

--- a/lib/api/response/oauth_token_response.g.dart
+++ b/lib/api/response/oauth_token_response.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'oauth_token_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+OauthTokenResponse _$OauthTokenResponseFromJson(Map<String, dynamic> json) {
+  return OauthTokenResponse(
+    accessToken: json['access_token'] as String?,
+    tokenType: json['token_type'] as String?,
+    expiresIn: (json['expires_in'] as num?)?.toDouble(),
+    refreshToken: json['refresh_token'] as String?,
+    createdAt: (json['created_at'] as num?)?.toDouble(),
+  );
+}
+
+Map<String, dynamic> _$OauthTokenResponseToJson(OauthTokenResponse instance) =>
+    <String, dynamic>{
+      'access_token': instance.accessToken,
+      'token_type': instance.tokenType,
+      'expires_in': instance.expiresIn,
+      'refresh_token': instance.refreshToken,
+      'created_at': instance.createdAt,
+    };

--- a/lib/api/response/oauth_token_response.g.dart
+++ b/lib/api/response/oauth_token_response.g.dart
@@ -8,11 +8,11 @@ part of 'oauth_token_response.dart';
 
 OauthTokenResponse _$OauthTokenResponseFromJson(Map<String, dynamic> json) {
   return OauthTokenResponse(
-    accessToken: json['access_token'] as String?,
-    tokenType: json['token_type'] as String?,
-    expiresIn: (json['expires_in'] as num?)?.toDouble(),
-    refreshToken: json['refresh_token'] as String?,
-    createdAt: (json['created_at'] as num?)?.toDouble(),
+    accessToken: json['access_token'] as String,
+    tokenType: json['token_type'] as String,
+    expiresIn: json['expires_in'] as int,
+    refreshToken: json['refresh_token'] as String,
+    createdAt: json['created_at'] as int,
   );
 }
 

--- a/lib/di/di.config.dart
+++ b/lib/di/di.config.dart
@@ -25,16 +25,16 @@ Future<_i1.GetIt> $initGetIt(_i1.GetIt get,
   final networkModule = _$NetworkModule();
   final localModule = _$LocalModule();
   gh.factory<_i3.LoginUseCase>(() => _i3.LoginUseCase(
-      get<_i4.OauthRepository>(), get<_i5.SharedPreferencesHelper>()));
+      get<_i4.OAuthRepository>(), get<_i5.SharedPreferencesHelper>()));
   gh.singleton<_i6.DioProvider>(_i6.DioProvider());
-  gh.singleton<_i7.OauthService>(
-      networkModule.provideOauthService(get<_i6.DioProvider>()));
+  gh.singleton<_i7.OAuthService>(
+      networkModule.provideOAuthService(get<_i6.DioProvider>()));
   await gh.singletonAsync<_i8.SharedPreferences>(() => localModule.sharedPref,
       preResolve: true);
   gh.singleton<_i5.SharedPreferencesHelper>(
       _i5.SharedPreferencesHelperImpl(get<_i8.SharedPreferences>()));
-  gh.singleton<_i4.OauthRepository>(
-      _i4.OauthRepositoryImpl(get<_i7.OauthService>()));
+  gh.singleton<_i4.OAuthRepository>(
+      _i4.OAuthRepositoryImpl(get<_i7.OAuthService>()));
   return get;
 }
 

--- a/lib/di/di.config.dart
+++ b/lib/di/di.config.dart
@@ -7,10 +7,12 @@
 import 'package:get_it/get_it.dart' as _i1;
 import 'package:injectable/injectable.dart' as _i2;
 
-import '../api/oauth_service.dart' as _i4;
-import 'module/network_module.dart' as _i5;
+import '../api/oauth_service.dart' as _i6;
+import '../api/repository/oauth_repository.dart' as _i4;
+import '../usecase/login_use_case.dart' as _i3;
+import 'module/network_module.dart' as _i7;
 import 'provider/dio_provider.dart'
-    as _i3; // ignore_for_file: unnecessary_lambdas
+    as _i5; // ignore_for_file: unnecessary_lambdas
 
 // ignore_for_file: lines_longer_than_80_chars
 /// initializes the registration of provided dependencies inside of [GetIt]
@@ -18,10 +20,14 @@ _i1.GetIt $initGetIt(_i1.GetIt get,
     {String? environment, _i2.EnvironmentFilter? environmentFilter}) {
   final gh = _i2.GetItHelper(get, environment, environmentFilter);
   final networkModule = _$NetworkModule();
-  gh.singleton<_i3.DioProvider>(_i3.DioProvider());
-  gh.singleton<_i4.OauthService>(
-      networkModule.provideOauthService(get<_i3.DioProvider>()));
+  gh.factory<_i3.LoginUseCase>(
+      () => _i3.LoginUseCase(get<_i4.OauthRepository>()));
+  gh.singleton<_i5.DioProvider>(_i5.DioProvider());
+  gh.singleton<_i6.OauthService>(
+      networkModule.provideOauthService(get<_i5.DioProvider>()));
+  gh.singleton<_i4.OauthRepository>(
+      _i4.OauthRepositoryImpl(get<_i6.OauthService>()));
   return get;
 }
 
-class _$NetworkModule extends _i5.NetworkModule {}
+class _$NetworkModule extends _i7.NetworkModule {}

--- a/lib/di/di.config.dart
+++ b/lib/di/di.config.dart
@@ -6,28 +6,38 @@
 
 import 'package:get_it/get_it.dart' as _i1;
 import 'package:injectable/injectable.dart' as _i2;
+import 'package:shared_preferences/shared_preferences.dart' as _i8;
 
-import '../api/oauth_service.dart' as _i6;
+import '../api/oauth_service.dart' as _i7;
 import '../api/repository/oauth_repository.dart' as _i4;
+import '../local/shared_preference_helper.dart' as _i5;
 import '../usecase/login_use_case.dart' as _i3;
-import 'module/network_module.dart' as _i7;
+import 'module/local_module.dart' as _i10;
+import 'module/network_module.dart' as _i9;
 import 'provider/dio_provider.dart'
-    as _i5; // ignore_for_file: unnecessary_lambdas
+    as _i6; // ignore_for_file: unnecessary_lambdas
 
 // ignore_for_file: lines_longer_than_80_chars
 /// initializes the registration of provided dependencies inside of [GetIt]
-_i1.GetIt $initGetIt(_i1.GetIt get,
-    {String? environment, _i2.EnvironmentFilter? environmentFilter}) {
+Future<_i1.GetIt> $initGetIt(_i1.GetIt get,
+    {String? environment, _i2.EnvironmentFilter? environmentFilter}) async {
   final gh = _i2.GetItHelper(get, environment, environmentFilter);
   final networkModule = _$NetworkModule();
-  gh.factory<_i3.LoginUseCase>(
-      () => _i3.LoginUseCase(get<_i4.OauthRepository>()));
-  gh.singleton<_i5.DioProvider>(_i5.DioProvider());
-  gh.singleton<_i6.OauthService>(
-      networkModule.provideOauthService(get<_i5.DioProvider>()));
+  final localModule = _$LocalModule();
+  gh.factory<_i3.LoginUseCase>(() => _i3.LoginUseCase(
+      get<_i4.OauthRepository>(), get<_i5.SharedPreferencesHelper>()));
+  gh.singleton<_i6.DioProvider>(_i6.DioProvider());
+  gh.singleton<_i7.OauthService>(
+      networkModule.provideOauthService(get<_i6.DioProvider>()));
+  await gh.singletonAsync<_i8.SharedPreferences>(() => localModule.sharedPref,
+      preResolve: true);
+  gh.singleton<_i5.SharedPreferencesHelper>(
+      _i5.SharedPreferencesHelperImpl(get<_i8.SharedPreferences>()));
   gh.singleton<_i4.OauthRepository>(
-      _i4.OauthRepositoryImpl(get<_i6.OauthService>()));
+      _i4.OauthRepositoryImpl(get<_i7.OauthService>()));
   return get;
 }
 
-class _$NetworkModule extends _i7.NetworkModule {}
+class _$NetworkModule extends _i9.NetworkModule {}
+
+class _$LocalModule extends _i10.LocalModule {}

--- a/lib/di/module/local_module.dart
+++ b/lib/di/module/local_module.dart
@@ -1,0 +1,9 @@
+import 'package:injectable/injectable.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+@module
+abstract class LocalModule {
+  @singleton
+  @preResolve
+  Future<SharedPreferences> get sharedPref => SharedPreferences.getInstance();
+}

--- a/lib/di/module/network_module.dart
+++ b/lib/di/module/network_module.dart
@@ -6,8 +6,8 @@ import 'package:injectable/injectable.dart';
 @module
 abstract class NetworkModule {
   @singleton
-  OauthService provideOauthService(DioProvider dioProvider) {
-    return OauthService(
+  OAuthService provideOAuthService(DioProvider dioProvider) {
+    return OAuthService(
       dioProvider.getNonAuthenticatedDio(),
       baseUrl: Env.restApiEndpoint,
     );

--- a/lib/local/shared_preference_helper.dart
+++ b/lib/local/shared_preference_helper.dart
@@ -1,0 +1,79 @@
+import 'package:injectable/injectable.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+const String _PREF_KEY_TYPE = 'PREF_KEY_TYPE';
+const String _PREF_KEY_ACCESS_TOKEN = 'PREF_KEY_TOKEN';
+const String _PREF_KEY_REFRESH_TOKEN = 'PREF_KEY_REFRESH_TOKEN';
+const String _PREF_KEY_TOKEN_EXPIRATION = 'PREF_KEY_TOKEN_EXPIRATION';
+
+abstract class SharedPreferencesHelper {
+  Future<String> getTokenType();
+
+  Future<void> saveTokenType(String tokenType);
+
+  Future<String> getAccessToken();
+
+  Future<void> saveAccessToken(String token);
+
+  Future<String> getRefreshToken();
+
+  Future<void> saveRefreshToken(String refreshToken);
+
+  Future<int> getTokenExpiration();
+
+  Future<void> saveTokenExpiration(int expiration);
+
+  Future<void> clear();
+}
+
+@Singleton(as: SharedPreferencesHelper)
+class SharedPreferencesHelperImpl implements SharedPreferencesHelper {
+  late SharedPreferences _prefs;
+
+  SharedPreferencesHelperImpl(this._prefs);
+
+  @override
+  Future<bool> saveTokenType(String tokenType) async {
+    return await _prefs.setString(_PREF_KEY_TYPE, tokenType);
+  }
+
+  @override
+  Future<String> getTokenType() async {
+    return _prefs.getString(_PREF_KEY_TYPE) ?? "";
+  }
+
+  @override
+  Future<String> getAccessToken() async {
+    return _prefs.getString(_PREF_KEY_ACCESS_TOKEN) ?? "";
+  }
+
+  @override
+  Future<bool> saveAccessToken(String token) async {
+    return await _prefs.setString(_PREF_KEY_ACCESS_TOKEN, token);
+  }
+
+  @override
+  Future<String> getRefreshToken() async {
+    return _prefs.getString(_PREF_KEY_REFRESH_TOKEN) ?? "";
+  }
+
+  @override
+  Future<bool> saveRefreshToken(String refreshToken) async {
+    return await _prefs.setString(_PREF_KEY_REFRESH_TOKEN, refreshToken);
+  }
+
+  @override
+  Future<int> getTokenExpiration() async {
+    return _prefs.getInt(_PREF_KEY_TOKEN_EXPIRATION) ?? 0;
+  }
+
+  @override
+  Future<bool> saveTokenExpiration(int expiration) async {
+    return await _prefs.setInt(_PREF_KEY_TOKEN_EXPIRATION, expiration);
+  }
+
+  @override
+  Future<void> clear() async {
+    _prefs.clear();
+  }
+}

--- a/lib/models/oauth_token.dart
+++ b/lib/models/oauth_token.dart
@@ -1,0 +1,13 @@
+class OAuthToken {
+  String accessToken;
+  String refreshToken;
+  String tokenType;
+  int expiresIn;
+
+  OAuthToken({
+    required this.accessToken,
+    required this.refreshToken,
+    required this.tokenType,
+    required this.expiresIn,
+  });
+}

--- a/lib/usecase/base/use_case_result.dart
+++ b/lib/usecase/base/use_case_result.dart
@@ -18,7 +18,7 @@ class Failed<T> extends Result<T> {
 
 class UseCaseException implements Exception {
   final NetworkExceptions networkExceptions;
-  final Exception actualException;
+  final Exception? actualException;
 
   UseCaseException(this.networkExceptions, this.actualException);
 }

--- a/lib/usecase/login_use_case.dart
+++ b/lib/usecase/login_use_case.dart
@@ -19,12 +19,13 @@ class LoginUseCase extends UseCase<void, LoginInput> {
   const LoginUseCase(this._repository);
 
   @override
-  Future<Result<void>> call(LoginInput credential) {
+  Future<Result<void>> call(LoginInput input) {
+    // TODO persist token result
     return _repository
-        .login(email: credential.email, password: credential.password)
+        .login(email: input.email, password: input.password)
         .then((value) =>
             Success(null) as Result<void>) // ignore: unnecessary_cast
-        .onError<Exception>((err, stackTrace) => Failed(
-            UseCaseException(NetworkExceptions.fromDioException(err), err)));
+        .onError<NetworkExceptions>(
+            (err, stackTrace) => Failed(UseCaseException(err, null)));
   }
 }

--- a/lib/usecase/login_use_case.dart
+++ b/lib/usecase/login_use_case.dart
@@ -1,0 +1,30 @@
+import 'dart:async';
+
+import 'package:flutter_survey/api/exception/network_exceptions.dart';
+import 'package:flutter_survey/api/repository/oauth_repository.dart';
+import 'package:flutter_survey/usecase/base/base_use_case.dart';
+import 'package:injectable/injectable.dart';
+
+class LoginInput {
+  final String email;
+  final String password;
+
+  LoginInput({required this.email, required this.password});
+}
+
+@Injectable()
+class LoginUseCase extends UseCase<void, LoginInput> {
+  final OauthRepository _repository;
+
+  const LoginUseCase(this._repository);
+
+  @override
+  Future<Result<void>> call(LoginInput credential) {
+    return _repository
+        .login(email: credential.email, password: credential.password)
+        .then((value) =>
+            Success(null) as Result<void>) // ignore: unnecessary_cast
+        .onError<Exception>((err, stackTrace) => Failed(
+            UseCaseException(NetworkExceptions.fromDioException(err), err)));
+  }
+}

--- a/lib/usecase/login_use_case.dart
+++ b/lib/usecase/login_use_case.dart
@@ -16,7 +16,7 @@ class LoginInput {
 
 @Injectable()
 class LoginUseCase extends UseCase<void, LoginInput> {
-  final OauthRepository _repository;
+  final OAuthRepository _repository;
   final SharedPreferencesHelper _sharedPreferencesHelper;
 
   const LoginUseCase(this._repository, this._sharedPreferencesHelper);

--- a/lib/usecase/login_use_case.dart
+++ b/lib/usecase/login_use_case.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 
 import 'package:flutter_survey/api/exception/network_exceptions.dart';
 import 'package:flutter_survey/api/repository/oauth_repository.dart';
+import 'package:flutter_survey/local/shared_preference_helper.dart';
+import 'package:flutter_survey/models/oauth_token.dart';
 import 'package:flutter_survey/usecase/base/base_use_case.dart';
 import 'package:injectable/injectable.dart';
 
@@ -15,17 +17,27 @@ class LoginInput {
 @Injectable()
 class LoginUseCase extends UseCase<void, LoginInput> {
   final OauthRepository _repository;
+  final SharedPreferencesHelper _sharedPreferencesHelper;
 
-  const LoginUseCase(this._repository);
+  const LoginUseCase(this._repository, this._sharedPreferencesHelper);
 
   @override
   Future<Result<void>> call(LoginInput input) {
-    // TODO persist token result
     return _repository
         .login(email: input.email, password: input.password)
-        .then((value) =>
-            Success(null) as Result<void>) // ignore: unnecessary_cast
+        .then((value) => _persistTokenData(value))
         .onError<NetworkExceptions>(
             (err, stackTrace) => Failed(UseCaseException(err, null)));
+  }
+
+  Result<dynamic> _persistTokenData(OAuthToken data) {
+    _sharedPreferencesHelper.saveTokenType(data.tokenType);
+    _sharedPreferencesHelper.saveAccessToken(data.accessToken);
+    _sharedPreferencesHelper.saveRefreshToken(data.refreshToken);
+
+    _sharedPreferencesHelper.saveTokenExpiration(
+        data.expiresIn * 1000 + DateTime.now().millisecondsSinceEpoch);
+
+    return Success(null);
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -483,6 +483,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.2.1"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.2"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.3"
   pedantic:
     dependency: transitive
     description:
@@ -497,6 +518,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.1.0"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.2"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -511,6 +539,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.5.0"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.2.3"
   pub_semver:
     dependency: transitive
     description:
@@ -546,6 +581,48 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.7"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.2"
+  shared_preferences_macos:
+    dependency: transitive
+    description:
+      name: shared_preferences_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.2"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.2"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.2"
   shelf:
     dependency: transitive
     description:
@@ -677,6 +754,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.2.7"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.0"
   xml:
     dependency: transitive
     description:
@@ -693,4 +777,4 @@ packages:
     version: "3.1.0"
 sdks:
   dart: ">=2.13.0 <3.0.0"
-  flutter: ">=1.24.0-7.0"
+  flutter: ">=2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   retrofit: ^2.0.0
   package_info_plus: ^1.0.6
   page_view_indicators: ^2.0.0
+  shared_preferences: ^2.0.7
 
 dev_dependencies:
   build_runner: ^2.1.2


### PR DESCRIPTION
https://github.com/luongvo/flutter-survey/issues/6

## What happened 👀

When the user comes to the Login screen, they can log in using their email and password.
 
## Insight 📝

- Invoke `/api/v1/oauth/token` to retrieve auth_token
  - Add login API into OauthService
  - Add OauthRepository
  - Add request and response models
  - Add LoginUseCase
 
## Proof Of Work 📹

```
I/flutter (13391): *** Request ***
I/flutter (13391): uri: https://survey-api.nimblehq.co/api/v1/oauth/token
I/flutter (13391): method: POST
I/flutter (13391): responseType: ResponseType.json
I/flutter (13391): followRedirects: true
I/flutter (13391): connectTimeout: 3000
I/flutter (13391): sendTimeout: 0
I/flutter (13391): receiveTimeout: 5000
I/flutter (13391): receiveDataWhenStatusError: true
I/flutter (13391): extra: {}
I/flutter (13391): headers:
I/flutter (13391):  content-type: application/json; charset=utf-8
I/flutter (13391): data:
I/flutter (13391): {grant_type: password, email: luong@nimblehq.co, password: 12345678, client_id: 6GbE8dhoz519l2N_F99StqoOs6Tcmm1rXgda4q__rIw, client_secret: _ayfIm7BeUAhx2W1OUqi20fwO3uNxfo1QstyKlFCgHw}
I/flutter (13391): 
I/flutter (13391): *** Response ***
I/flutter (13391): uri: https://survey-api.nimblehq.co/api/v1/oauth/token
I/flutter (13391): statusCode: 200
I/flutter (13391): headers:
I/flutter (13391):  date: Mon, 13 Sep 2021 19:25:50 GMT
I/flutter (13391):  transfer-encoding: chunked
I/flutter (13391):  vary: Accept-Encoding, Origin
I/flutter (13391):  content-encoding: gzip
I/flutter (13391):  pragma: no-cache
I/flutter (13391):  server: cloudflare
I/flutter (13391):  x-request-id: a7e8cf6f-fc54-494c-bfc7-f396bd43c8f2
I/flutter (13391):  cf-ray: 68e3c37d498b2483-HKG
I/flutter (13391):  etag: W/"a6038638c0a1fc3183ed1629274ad068"
I/flutter (13391):  x-frame-options: SAMEORIGIN
I/flutter (13391):  connection: keep-alive
I/flutter (13391):  cache-control: private, no-store
I/flutter (13391):  strict-transport-security: max-age=31536000; includeSubDomains
I/flutter (13391):  referrer-policy: strict-origin-when-cross-origin
I/flutter (13391):  cf-cache-status: DYNAMIC
I/flutter (13391):  report-to: {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=htsnD%2B8nmKccr0awwTT9B3DPAsEUJRdk1X0WgdlWZxh7XW3dGN%2FDx%2FFII83vRbiKokJ3W%2BKiHO%2F%2BRKPXzycbP8eIx8cOu1l5iw017mf6e4hOnPUqBizYomOHiH3kgGG5BwNqXxTsOwSWm3fmQCRxzfnivrMd"}],"group":"cf-nel","max_age":604800}
I/flutter (13391):  x-permitted-cross-domain-policies: none
I/flutter (13391):  content-type: application/json; charset=utf-8
I/flutter (13391):  expect-ct: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
I/flutter (13391):  x-xss-protection: 1; mode=block
I/flutter (13391):  alt-svc: h3=":443"; ma=86400, h3-29=":443"; ma=86400, h3-28=":443"; ma=86400, h3-27=":443"; ma=86400
I/flutter (13391):  x-download-options: noopen
I/flutter (13391):  nel: {"success_fraction":0,"report_to":"cf-nel","max_age":604800}
I/flutter (13391):  x-runtime: 0.403793
I/flutter (13391):  via: 1.1 vegur
I/flutter (13391):  x-content-type-options: nosniff
I/flutter (13391): Response Text:
I/flutter (13391): {"data":{"id":3184,"type":"token","attributes":{"access_token":"bUp7dMiVGli-6Ff0KA5PJPRlXrvGLo4zxzpBwBCDVkE","token_type":"Bearer","expires_in":7200,"refresh_token":"YmHTXs857xEEOANpdUR5eN5tfGHKppJUweubGfUo8p0","created_at":1631561150}}}
```

![image](https://user-images.githubusercontent.com/16315358/133313456-44748bb4-c887-4530-b89a-e7f5497b70ac.png)
