### PR TITLE
[#20] [Backend] As a user, I can submit answers for the survey

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ![Lint & Test](https://github.com/luongvo/flutter-survey/actions/workflows/test.yml/badge.svg)
+[![codecov](https://codecov.io/gh/luongvo/flutter-survey/branch/develop/graph/badge.svg?token=Q16QDY3936)](https://codecov.io/gh/luongvo/flutter-survey)
 
 # flutter_survey
 

--- a/lib/api/repository/survey_repository.dart
+++ b/lib/api/repository/survey_repository.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_survey/api/exception/network_exceptions.dart';
+import 'package:flutter_survey/api/request/submit_survey_request.dart';
 import 'package:flutter_survey/api/survey_service.dart';
 import 'package:flutter_survey/models/survey.dart';
 import 'package:flutter_survey/models/survey_detail.dart';
@@ -8,6 +9,11 @@ abstract class SurveyRepository {
   Future<List<Survey>> getSurveys(int pageNumber, int pageSize);
 
   Future<SurveyDetail> getSurveyDetail(String surveyId);
+
+  Future<void> submitSurvey(
+    String surveyId,
+    List<SubmitQuestion> questions,
+  );
 }
 
 @Singleton(as: SurveyRepository)
@@ -34,6 +40,21 @@ class SurveyRepositoryImpl extends SurveyRepository {
     try {
       final response = await _surveyService.getSurveyDetail(surveyId);
       return SurveyDetail.fromSurveyDetailResponse(response);
+    } catch (exception) {
+      throw NetworkExceptions.fromDioException(exception);
+    }
+  }
+
+  @override
+  Future<void> submitSurvey(
+    String surveyId,
+    List<SubmitQuestion> questions,
+  ) async {
+    try {
+      return await _surveyService.submitSurvey(SubmitSurveyRequest(
+        surveyId: surveyId,
+        questions: questions,
+      ));
     } catch (exception) {
       throw NetworkExceptions.fromDioException(exception);
     }

--- a/lib/api/request/submit_survey_request.dart
+++ b/lib/api/request/submit_survey_request.dart
@@ -1,0 +1,42 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'submit_survey_request.g.dart';
+
+@JsonSerializable()
+class SubmitSurveyRequest {
+  final String surveyId;
+  final List<SubmitQuestion> questions;
+
+  SubmitSurveyRequest({required this.surveyId, required this.questions});
+
+  factory SubmitSurveyRequest.fromJson(Map<String, dynamic> json) =>
+      _$SubmitSurveyRequestFromJson(json);
+
+  Map<String, dynamic> toJson() => _$SubmitSurveyRequestToJson(this);
+}
+
+@JsonSerializable()
+class SubmitQuestion {
+  final String id;
+  final List<SubmitAnswer> answers;
+
+  SubmitQuestion({required this.id, required this.answers});
+
+  factory SubmitQuestion.fromJson(Map<String, dynamic> json) =>
+      _$SubmitQuestionFromJson(json);
+
+  Map<String, dynamic> toJson() => _$SubmitQuestionToJson(this);
+}
+
+@JsonSerializable()
+class SubmitAnswer {
+  final String id;
+  final String answer;
+
+  SubmitAnswer({required this.id, required this.answer});
+
+  factory SubmitAnswer.fromJson(Map<String, dynamic> json) =>
+      _$SubmitAnswerFromJson(json);
+
+  Map<String, dynamic> toJson() => _$SubmitAnswerToJson(this);
+}

--- a/lib/api/survey_service.dart
+++ b/lib/api/survey_service.dart
@@ -1,4 +1,5 @@
 import 'package:dio/dio.dart';
+import 'package:flutter_survey/api/request/submit_survey_request.dart';
 import 'package:flutter_survey/api/response/survey_detail_response.dart';
 import 'package:flutter_survey/api/response/surveys_response.dart';
 import 'package:retrofit/retrofit.dart';
@@ -23,4 +24,7 @@ abstract class SurveyService {
   Future<SurveyDetailResponse> getSurveyDetail(
     @Path('surveyId') String surveyId,
   );
+
+  @POST('/v1/responses')
+  Future<void> submitSurvey(@Body() SubmitSurveyRequest body);
 }

--- a/lib/usecase/submit_survey_use_case.dart
+++ b/lib/usecase/submit_survey_use_case.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_survey/api/exception/network_exceptions.dart';
+import 'package:flutter_survey/api/repository/survey_repository.dart';
+import 'package:flutter_survey/api/request/submit_survey_request.dart';
+import 'package:flutter_survey/usecase/base/base_use_case.dart';
+import 'package:injectable/injectable.dart';
+
+class SubmitSurveyInput {
+  String surveyId;
+  List<SubmitQuestion> questions;
+
+  SubmitSurveyInput({
+    required this.surveyId,
+    required this.questions,
+  });
+}
+
+@Injectable()
+class SubmitSurveyUseCase extends UseCase<void, SubmitSurveyInput> {
+  final SurveyRepository _surveyRepository;
+
+  const SubmitSurveyUseCase(this._surveyRepository);
+
+  @override
+  Future<Result<void>> call(SubmitSurveyInput params) {
+    return _surveyRepository
+        .submitSurvey(params.surveyId, params.questions)
+        .then((value) =>
+            Success(null) as Result<void>) // ignore: unnecessary_cast
+        .onError<NetworkExceptions>(
+            (err, stackTrace) => Failed(UseCaseException(err)));
+  }
+}

--- a/test/api/repository/survey_repository_test.dart
+++ b/test/api/repository/survey_repository_test.dart
@@ -1,5 +1,3 @@
-import 'dart:ffi';
-
 import 'package:flutter_survey/api/exception/network_exceptions.dart';
 import 'package:flutter_survey/api/repository/survey_repository.dart';
 import 'package:flutter_survey/api/response/survey_detail_response.dart';
@@ -74,7 +72,7 @@ void main() {
     test(
         'When calling submitSurvey successfully, it returns corresponding response',
         () async {
-      when(mockSurveyService.submitSurvey(any)).thenAnswer((_) async => Void);
+      when(mockSurveyService.submitSurvey(any)).thenAnswer((_) async => null);
       await surveyRepository.submitSurvey("1", []);
     });
 

--- a/test/api/repository/survey_repository_test.dart
+++ b/test/api/repository/survey_repository_test.dart
@@ -1,3 +1,5 @@
+import 'dart:ffi';
+
 import 'package:flutter_survey/api/exception/network_exceptions.dart';
 import 'package:flutter_survey/api/repository/survey_repository.dart';
 import 'package:flutter_survey/api/response/survey_detail_response.dart';
@@ -65,6 +67,21 @@ void main() {
         () async {
       when(mockSurveyService.getSurveyDetail(any)).thenThrow(MockDioError());
       final result = () => surveyRepository.getSurveyDetail("1");
+
+      expect(result, throwsA(isA<NetworkExceptions>()));
+    });
+
+    test(
+        'When calling submitSurvey successfully, it returns corresponding response',
+        () async {
+      when(mockSurveyService.submitSurvey(any)).thenAnswer((_) async => Void);
+      await surveyRepository.submitSurvey("1", []);
+    });
+
+    test('When calling submitSurvey failed, it returns NetworkExceptions error',
+        () async {
+      when(mockSurveyService.submitSurvey(any)).thenThrow(MockDioError());
+      final result = () => surveyRepository.submitSurvey("1", []);
 
       expect(result, throwsA(isA<NetworkExceptions>()));
     });

--- a/test/usecase/submit_survey_use_case_test.dart
+++ b/test/usecase/submit_survey_use_case_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_survey/api/exception/network_exceptions.dart';
+import 'package:flutter_survey/usecase/base/base_use_case.dart';
+import 'package:flutter_survey/usecase/submit_survey_use_case.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+import '../mock/mock_data.mocks.dart';
+
+void main() {
+  group('SubmitSurveyUseCaseTest', () {
+    late MockSurveyRepository mockRepository;
+    late SubmitSurveyUseCase useCase;
+
+    final input = SubmitSurveyInput(
+      surveyId: "id",
+      questions: [],
+    );
+
+    setUp(() async {
+      mockRepository = MockSurveyRepository();
+      useCase = SubmitSurveyUseCase(mockRepository);
+    });
+
+    test('When calling API with valid data, it returns Success result',
+        () async {
+      when(mockRepository.submitSurvey(any, any)).thenAnswer((_) async => null);
+      final result = await useCase.call(input);
+
+      expect(result, isA<Success>());
+    });
+
+    test('When calling API with invalid data, it returns Failed result',
+        () async {
+      when(mockRepository.submitSurvey(any, any))
+          .thenAnswer((_) => Future.error(
+                NetworkExceptions.unauthorisedRequest(),
+              ));
+      final result = await useCase.call(input);
+
+      expect(result, isA<Failed>());
+      expect((result as Failed).exception.actualException,
+          NetworkExceptions.unauthorisedRequest());
+    });
+  });
+}


### PR DESCRIPTION
https://github.com/luongvo/flutter-survey/issues/20

## What happened 👀

After answering all provided questions, the user can submit their answers for the survey.

- Call `POST /api/v1/responses`
 
## Insight 📝

N/A
 
## Proof Of Work 📹

```
I/flutter ( 9824): *** Request ***
I/flutter ( 9824): uri: https://survey-api.nimblehq.co/api/v1/responses
I/flutter ( 9824): method: POST
I/flutter ( 9824): responseType: ResponseType.json
I/flutter ( 9824): followRedirects: true
I/flutter ( 9824): connectTimeout: 3000
I/flutter ( 9824): sendTimeout: 0
I/flutter ( 9824): receiveTimeout: 5000
I/flutter ( 9824): receiveDataWhenStatusError: true
I/flutter ( 9824): extra: {}
I/flutter ( 9824): headers:
I/flutter ( 9824):  content-type: application/json; charset=utf-8
I/flutter ( 9824):  Authorization: Bearer oeoKTF2F6WUK8K1TfNsIbP3nV-RxksQydFtosmWXv1g
I/flutter ( 9824): data:
I/flutter ( 9824): {survey_id: ed1d4f0ff19a56073a14, questions: [Instance of 'SubmitQuestion']}
I/flutter ( 9824): 
I/flutter ( 9824): *** Response ***
I/flutter ( 9824): uri: https://survey-api.nimblehq.co/api/v1/responses
I/flutter ( 9824): statusCode: 201
I/flutter ( 9824): headers:
I/flutter ( 9824):  date: Sun, 17 Jul 2022 13:17:17 GMT
I/flutter ( 9824):  transfer-encoding: chunked
I/flutter ( 9824):  content-encoding: gzip
I/flutter ( 9824):  vary: Accept-Encoding, Origin
I/flutter ( 9824):  server: cloudflare
I/flutter ( 9824):  x-request-id: e238e0a0-0702-4c7f-bf61-ca72258f1065
I/flutter ( 9824):  cf-ray: 72c341c56efcb451-HKG
I/flutter ( 9824):  etag: W/"08b33a6adfba43ba6db6703c0f3afe53"
I/flutter ( 9824):  x-frame-options: SAMEORIGIN
I/flutter ( 9824):  connection: keep-alive
I/flutter ( 9824):  cache-control: max-age=0, private, must-revalidate
I/flutter ( 9824):  strict-transport-security: max-age=31536000; includeSubDomains
I/flutter ( 9824):  referrer-policy: strict-origin-when-cross-origin
I/flutter ( 9824):  cf-cache-status: DYNAMIC
I/flutter ( 9824):  report-to: {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=jwTjgfSpr6db6%2BIuiqxAkKBoivR90gd6RBKLLlt6ibXPqFyJZytfBWxAOb3iNsxz65LAq%2FBTwE3ZndOWnSQXtckds2ixcAQFLTHIpKOxV%2B%2BcAUCImpCkhcSIguzZZCfaEsH1NLCO7aWgA4mKAQu%2B1oF82p6O"}],"group":"cf-nel","max_age":604800}
I/flutter ( 9824):  x-permitted-cross-domain-policies: none
I/flutter ( 9824):  content-type: application/json; charset=utf-8
I/flutter ( 9824):  expect-ct: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
I/flutter ( 9824):  x-xss-protection: 1; mode=block
I/flutter ( 9824):  alt-svc: h3=":443"; ma=86400, h3-29=":443"; ma=86400
I/flutter ( 9824):  x-download-options: noopen
I/flutter ( 9824):  nel: {"success_fraction":0,"report_to":"cf-nel","max_age":604800}
I/flutter ( 9824):  x-runtime: 0.019392
I/flutter ( 9824):  via: 1.1 vegur
I/flutter ( 9824):  x-content-type-options: nosniff
I/flutter ( 9824): Response Text:
I/flutter ( 9824): {}
```
