### PR TITLE
[#26] [Backend] As a user, I can see my user profile on Home screen

### DIFF
--- a/lib/api/repository/user_repository.dart
+++ b/lib/api/repository/user_repository.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_survey/api/exception/network_exceptions.dart';
+import 'package:flutter_survey/api/user_service.dart';
+import 'package:flutter_survey/models/user.dart';
+import 'package:injectable/injectable.dart';
+
+abstract class UserRepository {
+  Future<User> getUserProfile();
+}
+
+@Singleton(as: UserRepository)
+class UserRepositoryImpl extends UserRepository {
+  UserService _userService;
+
+  UserRepositoryImpl(this._userService);
+
+  @override
+  Future<User> getUserProfile() async {
+    try {
+      final response = await _userService.getUserProfile();
+      return User.fromUserResponse(response);
+    } catch (exception) {
+      throw NetworkExceptions.fromDioException(exception);
+    }
+  }
+}

--- a/lib/api/response/user_response.dart
+++ b/lib/api/response/user_response.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_survey/api/response/base/base_response_converter.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'user_response.g.dart';
+
+@JsonSerializable()
+class UserResponse {
+  final String id;
+  final String email;
+  final String name;
+  final String avatarUrl;
+
+  UserResponse({
+    required this.id,
+    required this.email,
+    required this.name,
+    required this.avatarUrl,
+  });
+
+  factory UserResponse.fromJson(Map<String, dynamic> json) =>
+      _$UserResponseFromJson(fromJsonApi(json));
+}

--- a/lib/api/survey_service.dart
+++ b/lib/api/survey_service.dart
@@ -6,10 +6,6 @@ import 'package:retrofit/retrofit.dart';
 
 part 'survey_service.g.dart';
 
-class SurveyApi {
-  SurveyApi._();
-}
-
 @RestApi()
 abstract class SurveyService {
   factory SurveyService(Dio dio, {String baseUrl}) = _SurveyService;

--- a/lib/api/user_service.dart
+++ b/lib/api/user_service.dart
@@ -4,10 +4,6 @@ import 'package:retrofit/retrofit.dart';
 
 part 'user_service.g.dart';
 
-class SurveyApi {
-  SurveyApi._();
-}
-
 @RestApi()
 abstract class UserService {
   factory UserService(Dio dio, {String baseUrl}) = _UserService;

--- a/lib/api/user_service.dart
+++ b/lib/api/user_service.dart
@@ -1,0 +1,17 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_survey/api/response/user_response.dart';
+import 'package:retrofit/retrofit.dart';
+
+part 'user_service.g.dart';
+
+class SurveyApi {
+  SurveyApi._();
+}
+
+@RestApi()
+abstract class UserService {
+  factory UserService(Dio dio, {String baseUrl}) = _UserService;
+
+  @GET('/v1/me')
+  Future<UserResponse> getUserProfile();
+}

--- a/lib/di/module/network_module.dart
+++ b/lib/di/module/network_module.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_survey/api/oauth_service.dart';
 import 'package:flutter_survey/api/survey_service.dart';
+import 'package:flutter_survey/api/user_service.dart';
 import 'package:flutter_survey/di/provider/dio_provider.dart';
 import 'package:flutter_survey/env.dart';
 import 'package:injectable/injectable.dart';
@@ -17,6 +18,14 @@ abstract class NetworkModule {
   @singleton
   SurveyService provideSurveyService(DioProvider dioProvider) {
     return SurveyService(
+      dioProvider.getAuthenticatedDio(),
+      baseUrl: Env.restApiEndpoint,
+    );
+  }
+
+  @singleton
+  UserService provideUserService(DioProvider dioProvider) {
+    return UserService(
       dioProvider.getAuthenticatedDio(),
       baseUrl: Env.restApiEndpoint,
     );

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -1,0 +1,33 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter_survey/api/response/user_response.dart';
+
+class User extends Equatable {
+  final String id;
+  final String email;
+  final String name;
+  final String avatarUrl;
+
+  User({
+    required this.id,
+    required this.email,
+    required this.name,
+    required this.avatarUrl,
+  });
+
+  @override
+  List<Object?> get props => [
+        id,
+        email,
+        name,
+        avatarUrl,
+      ];
+
+  factory User.fromUserResponse(UserResponse response) {
+    return User(
+      id: response.id,
+      email: response.email,
+      name: response.name,
+      avatarUrl: response.avatarUrl,
+    );
+  }
+}

--- a/lib/usecase/get_user_profile_use_case.dart
+++ b/lib/usecase/get_user_profile_use_case.dart
@@ -5,13 +5,13 @@ import 'package:flutter_survey/usecase/base/base_use_case.dart';
 import 'package:injectable/injectable.dart';
 
 @Injectable()
-class GetUserProfileUseCase extends UseCase<User, void> {
+class GetUserProfileUseCase extends NoParamsUseCase<User> {
   final UserRepository _userRepository;
 
   const GetUserProfileUseCase(this._userRepository);
 
   @override
-  Future<Result<User>> call(void params) {
+  Future<Result<User>> call() {
     return _userRepository
         .getUserProfile()
         .then((value) =>

--- a/lib/usecase/get_user_profile_use_case.dart
+++ b/lib/usecase/get_user_profile_use_case.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_survey/api/exception/network_exceptions.dart';
+import 'package:flutter_survey/api/repository/user_repository.dart';
+import 'package:flutter_survey/models/user.dart';
+import 'package:flutter_survey/usecase/base/base_use_case.dart';
+import 'package:injectable/injectable.dart';
+
+@Injectable()
+class GetUserProfileUseCase extends UseCase<User, void> {
+  final UserRepository _userRepository;
+
+  const GetUserProfileUseCase(this._userRepository);
+
+  @override
+  Future<Result<User>> call(void params) {
+    return _userRepository
+        .getUserProfile()
+        .then((value) =>
+            Success(value) as Result<User>) // ignore: unnecessary_cast
+        .onError<NetworkExceptions>(
+            (err, stackTrace) => Failed(UseCaseException(err)));
+  }
+}

--- a/test/api/repository/user_repository_test.dart
+++ b/test/api/repository/user_repository_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_survey/api/exception/network_exceptions.dart';
+import 'package:flutter_survey/api/repository/user_repository.dart';
+import 'package:flutter_survey/api/response/user_response.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+import '../../mock/mock_data.mocks.dart';
+import '../../utils/file_util.dart';
+
+void main() {
+  group("UserRepositoryTest", () {
+    late MockUserService mockUserService;
+    late UserRepository userRepository;
+
+    setUp(() async {
+      mockUserService = MockUserService();
+      userRepository = UserRepositoryImpl(mockUserService);
+    });
+
+    test(
+        'When calling getUserProfile successfully, it returns corresponding response',
+        () async {
+      final userJson = await FileUtil.loadFile('test_resources/user.json');
+      final response = UserResponse.fromJson(userJson);
+
+      when(mockUserService.getUserProfile()).thenAnswer((_) async => response);
+      final result = await userRepository.getUserProfile();
+
+      expect(result.name, "Luong");
+      expect(result.email, "luong@nimblehq.co");
+    });
+
+    test(
+        'When calling getUserProfile failed, it returns NetworkExceptions error',
+        () async {
+      when(mockUserService.getUserProfile()).thenThrow(MockDioError());
+      final result = () => userRepository.getUserProfile();
+
+      expect(result, throwsA(isA<NetworkExceptions>()));
+    });
+  });
+}

--- a/test/mock/mock_data.dart
+++ b/test/mock/mock_data.dart
@@ -2,13 +2,17 @@ import 'package:dio/dio.dart';
 import 'package:flutter_survey/api/oauth_service.dart';
 import 'package:flutter_survey/api/repository/oauth_repository.dart';
 import 'package:flutter_survey/api/repository/survey_repository.dart';
+import 'package:flutter_survey/api/repository/user_repository.dart';
 import 'package:flutter_survey/api/survey_service.dart';
+import 'package:flutter_survey/api/user_service.dart';
 import 'package:flutter_survey/models/question.dart';
 import 'package:flutter_survey/models/survey.dart';
 import 'package:flutter_survey/models/survey_detail.dart';
+import 'package:flutter_survey/models/user.dart';
 import 'package:flutter_survey/usecase/base/base_use_case.dart';
 import 'package:flutter_survey/usecase/get_survey_detail_use_case.dart';
 import 'package:flutter_survey/usecase/get_surveys_use_case.dart';
+import 'package:flutter_survey/usecase/get_user_profile_use_case.dart';
 import 'package:flutter_survey/usecase/login_use_case.dart';
 import 'package:flutter_survey/usecase/submit_survey_use_case.dart';
 import 'package:mockito/annotations.dart';
@@ -16,15 +20,19 @@ import 'package:mockito/annotations.dart';
 @GenerateMocks([
   OAuthService,
   SurveyService,
+  UserService,
   OAuthRepository,
   SurveyRepository,
+  UserRepository,
   LoginUseCase,
   GetSurveysUseCase,
   GetSurveyDetailUseCase,
   SubmitSurveyUseCase,
+  GetUserProfileUseCase,
   Survey,
   SurveyDetail,
   Question,
+  User,
   UseCaseException,
   DioError
 ])

--- a/test/usecase/get_user_profile_use_case_test.dart
+++ b/test/usecase/get_user_profile_use_case_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_survey/api/exception/network_exceptions.dart';
+import 'package:flutter_survey/usecase/base/base_use_case.dart';
+import 'package:flutter_survey/usecase/get_user_profile_use_case.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+import '../mock/mock_data.mocks.dart';
+
+void main() {
+  group('GetUserProfileUseCaseTest', () {
+    late MockUserRepository mockRepository;
+    late GetUserProfileUseCase useCase;
+
+    setUp(() async {
+      mockRepository = MockUserRepository();
+      useCase = GetUserProfileUseCase(mockRepository);
+    });
+
+    test('When calling API with valid data, it returns Success result',
+        () async {
+      final user = MockUser();
+
+      when(mockRepository.getUserProfile()).thenAnswer((_) async => user);
+      final result = await useCase.call();
+
+      expect(result, isA<Success>());
+    });
+
+    test('When calling API with invalid data, it returns Failed result',
+        () async {
+      when(mockRepository.getUserProfile()).thenAnswer((_) => Future.error(
+            NetworkExceptions.unauthorisedRequest(),
+          ));
+      final result = await useCase.call();
+
+      expect(result, isA<Failed>());
+      expect((result as Failed).exception.actualException,
+          NetworkExceptions.unauthorisedRequest());
+    });
+  });
+}

--- a/test_resources/user.json
+++ b/test_resources/user.json
@@ -1,0 +1,11 @@
+{
+  "data": {
+    "id": "31",
+    "type": "user",
+    "attributes": {
+      "email": "luong@nimblehq.co",
+      "name": "Luong",
+      "avatar_url": "https://secure.gravatar.com/avatar/8fae17b9d0c4cca18a9661bcdf650f23"
+    }
+  }
+}


### PR DESCRIPTION
https://github.com/luongvo/flutter-survey/issues/26

## What happened 👀

After logged in successfully, I can see my user profile on `Home` screen.

- Call `GET {{base-url}}/api/v1/me` with Authorization.
 
## Insight 📝

- We need to setup a new `UserService`, `UserRepository` to include new APIs about user.
 
## Proof Of Work 📹

```
I/flutter (29682): *** Request ***
I/flutter (29682): uri: https://survey-api.nimblehq.co/api/v1/surveys?page%5Bnumber%5D=1&page%5Bsize%5D=10
I/flutter (29682): method: GET
I/flutter (29682): responseType: ResponseType.json
I/flutter (29682): followRedirects: true
I/flutter (29682): connectTimeout: 3000
I/flutter (29682): sendTimeout: 0
I/flutter (29682): receiveTimeout: 5000
I/flutter (29682): receiveDataWhenStatusError: true
I/flutter (29682): extra: {}
I/flutter (29682): headers:
I/flutter (29682):  Authorization: Bearer AIiRU0SV37LK16YmJAmN-LeClKWZjD_4gwJCIkC4fdc
I/flutter (29682): data:
I/flutter (29682): {}
I/flutter (29682): 
V/FA      (29682): Inactivity, disconnecting from the service
I/flutter (29682): *** Response ***
I/flutter (29682): uri: https://survey-api.nimblehq.co/api/v1/me
I/flutter (29682): statusCode: 200
I/flutter (29682): headers:
I/flutter (29682):  date: Mon, 18 Jul 2022 06:54:18 GMT
I/flutter (29682):  transfer-encoding: chunked
I/flutter (29682):  content-encoding: gzip
I/flutter (29682):  vary: Accept-Encoding, Origin
I/flutter (29682):  server: cloudflare
I/flutter (29682):  x-request-id: 9d3c1460-aec4-4ea1-9858-33d3f2195a38
I/flutter (29682):  cf-ray: 72c94e203cfe221c-HKG
I/flutter (29682):  etag: W/"7b5ecbae2e28b0fa6089654477f8548e"
I/flutter (29682):  x-frame-options: SAMEORIGIN
I/flutter (29682):  connection: keep-alive
I/flutter (29682):  cache-control: max-age=0, private, must-revalidate
I/flutter (29682):  strict-transport-security: max-age=31536000; includeSubDomains
I/flutter (29682):  referrer-policy: strict-origin-when-cross-origin
I/flutter (29682):  cf-cache-status: DYNAMIC
I/flutter (29682):  report-to: {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=q%2BnBpQusNx5%2BqXQm3500f%2FB2ifW8FW4nfmpdtRr846r3sKTVj2PLkgdetm0I9MH38yglNZPfjaHgs58H32YmBfHWXlBo7OmIvm4%2BGg0NxUnTVxNzo09gltcNsa7Z20o%2Bfxyszx%2BuLkPdSAKzwm2c6XotmTco"}],"group":"cf-nel","max_age":604800}
I/flutter (29682):  x-permitted-cross-domain-policies: none
I/flutter (29682):  content-type: application/json; charset=utf-8
I/flutter (29682):  expect-ct: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
I/flutter (29682):  x-xss-protection: 1; mode=block
I/flutter (29682):  alt-svc: h3=":443"; ma=86400, h3-29=":443"; ma=86400
I/flutter (29682):  x-download-options: noopen
I/flutter (29682):  nel: {"success_fraction":0,"report_to":"cf-nel","max_age":604800}
I/flutter (29682):  x-runtime: 0.050944
I/flutter (29682):  via: 1.1 vegur
I/flutter (29682):  x-content-type-options: nosniff
I/flutter (29682): Response Text:
I/flutter (29682): {"data":{"id":"31","type":"user","attributes":{"email":"luong@nimblehq.co","name":"Luong","avatar_url":"https://secure.gravatar.com/avatar/8fae17b9d0c4cca18a9661bcdf650f23"}}}
```
