### PR TITLE
[#35] [UI] As a user, I can pull to refresh the survey list in Home screen

### DIFF
--- a/lib/pages/home/home_page.dart
+++ b/lib/pages/home/home_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_survey/di/di.dart';
 import 'package:flutter_survey/extensions/build_context_ext.dart';
+import 'package:flutter_survey/gen/colors.gen.dart';
 import 'package:flutter_survey/models/user.dart';
 import 'package:flutter_survey/pages/home/home_drawer.dart';
 import 'package:flutter_survey/pages/home/home_header.dart';
@@ -84,28 +85,40 @@ class _HomePageState extends ConsumerState<HomePage> {
     return Scaffold(
       endDrawer: HomeDrawer(),
       resizeToAvoidBottomInset: false,
-      body: Stack(
-        children: <Widget>[
-          SurveyPageViewer(
-            surveys: surveys,
-            currentPageNotifier: _currentPageNotifier,
-          ),
-          SafeArea(
-            child: Padding(
-              padding: const EdgeInsets.all(Dimens.defaultMarginPadding),
-              child: Column(
-                children: [
-                  HomeHeader(),
-                  Expanded(
-                    child: const SizedBox.shrink(),
-                  ),
-                  _buildCircleIndicator(surveys),
-                  SizedBox(height: Dimens.homeFooterHeight)
-                ],
+      body: RefreshIndicator(
+        color: ColorName.blackRussian,
+        onRefresh: () => Future.delayed(
+          // TODO integration https://github.com/luongvo/flutter-survey/issues/36
+          Duration(seconds: 5),
+        ),
+        child: Stack(
+          children: <Widget>[
+            SurveyPageViewer(
+              surveys: surveys,
+              currentPageNotifier: _currentPageNotifier,
+            ),
+            // Workaround to allow the page to be scrolled vertically to refresh on top
+            FractionallySizedBox(
+              heightFactor: 0.3,
+              child: ListView(),
+            ),
+            SafeArea(
+              child: Padding(
+                padding: const EdgeInsets.all(Dimens.defaultMarginPadding),
+                child: Column(
+                  children: [
+                    HomeHeader(),
+                    Expanded(
+                      child: const SizedBox.shrink(),
+                    ),
+                    _buildCircleIndicator(surveys),
+                    SizedBox(height: Dimens.homeFooterHeight)
+                  ],
+                ),
               ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
https://github.com/luongvo/flutter-survey/issues/35

## What happened 👀

- Add `RefreshIndicator` to enable pull down to refresh on Home screen.
 
## Insight 📝

- Home screen contains only a **horizontal** `PageView`, while `RefreshIndicator` can [only be used with a **vertical scroll view**](https://api.flutter.dev/flutter/material/RefreshIndicator-class.html).
- We need to apply a workaround: add a 1/3 screen `ListView` on top on Home screen so 1/3 of Home screen content will be scrolled vertically for pull down to refresh, 2/3 of Home screen content will be scrolled horizontally for Survey list swiping.
 
## Proof Of Work 📹


https://user-images.githubusercontent.com/16315358/183977844-8b48e545-e23d-4c87-b276-557d9103109a.mp4


