### PR TITLE
[#9] [Backend] As a user, I can reset my password

### DIFF
--- a/lib/api/oauth_service.dart
+++ b/lib/api/oauth_service.dart
@@ -2,6 +2,7 @@ import 'package:dio/dio.dart';
 import 'package:flutter_survey/api/request/oauth_logout_request.dart';
 import 'package:flutter_survey/api/request/oauth_refresh_token_request.dart';
 import 'package:flutter_survey/api/request/oauth_token_request.dart';
+import 'package:flutter_survey/api/request/reset_password_request.dart';
 import 'package:flutter_survey/api/response/oauth_token_response.dart';
 import 'package:retrofit/retrofit.dart';
 
@@ -22,5 +23,10 @@ abstract class OAuthService {
   @POST('/v1/oauth/token')
   Future<OAuthTokenResponse> refreshToken(
     @Body() OAuthRefreshTokenRequest body,
+  );
+
+  @POST('/v1/passwords')
+  Future<void> resetPassword(
+    @Body() ResetPasswordRequest body,
   );
 }

--- a/lib/api/repository/oauth_repository.dart
+++ b/lib/api/repository/oauth_repository.dart
@@ -3,6 +3,7 @@ import 'package:flutter_survey/api/oauth_service.dart';
 import 'package:flutter_survey/api/request/oauth_logout_request.dart';
 import 'package:flutter_survey/api/request/oauth_refresh_token_request.dart';
 import 'package:flutter_survey/api/request/oauth_token_request.dart';
+import 'package:flutter_survey/api/request/reset_password_request.dart';
 import 'package:flutter_survey/env.dart';
 import 'package:flutter_survey/models/oauth_token.dart';
 import 'package:injectable/injectable.dart';
@@ -19,6 +20,10 @@ abstract class OAuthRepository {
 
   Future<OAuthToken> refreshToken({
     required String refreshToken,
+  });
+
+  Future<void> resetPassword({
+    required String email,
   });
 }
 
@@ -82,6 +87,23 @@ class OAuthRepositoryImpl extends OAuthRepository {
         tokenType: response.tokenType,
         expiresIn: response.expiresIn,
       );
+    } catch (exception) {
+      throw NetworkExceptions.fromDioException(exception);
+    }
+  }
+
+  @override
+  Future<void> resetPassword({
+    required String email,
+  }) async {
+    try {
+      await _oauthService.resetPassword(ResetPasswordRequest(
+        user: UserRequest(
+          email: email,
+        ),
+        clientId: Env.basicAuthClientId,
+        clientSecret: Env.basicAuthClientSecret,
+      ));
     } catch (exception) {
       throw NetworkExceptions.fromDioException(exception);
     }

--- a/lib/api/request/reset_password_request.dart
+++ b/lib/api/request/reset_password_request.dart
@@ -1,0 +1,35 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'reset_password_request.g.dart';
+
+@JsonSerializable()
+class ResetPasswordRequest {
+  final UserRequest user;
+  final String clientId;
+  final String clientSecret;
+
+  ResetPasswordRequest({
+    required this.user,
+    required this.clientId,
+    required this.clientSecret,
+  });
+
+  factory ResetPasswordRequest.fromJson(Map<String, dynamic> json) =>
+      _$ResetPasswordRequestFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ResetPasswordRequestToJson(this);
+}
+
+@JsonSerializable()
+class UserRequest {
+  final String email;
+
+  UserRequest({
+    required this.email,
+  });
+
+  factory UserRequest.fromJson(Map<String, dynamic> json) =>
+      _$UserRequestFromJson(json);
+
+  Map<String, dynamic> toJson() => _$UserRequestToJson(this);
+}

--- a/lib/usecase/reset_password_use_case.dart
+++ b/lib/usecase/reset_password_use_case.dart
@@ -1,0 +1,23 @@
+import 'dart:async';
+
+import 'package:flutter_survey/api/exception/network_exceptions.dart';
+import 'package:flutter_survey/api/repository/oauth_repository.dart';
+import 'package:flutter_survey/usecase/base/base_use_case.dart';
+import 'package:injectable/injectable.dart';
+
+@Injectable()
+class ResetPasswordUseCase extends UseCase<void, String> {
+  final OAuthRepository _repository;
+
+  const ResetPasswordUseCase(this._repository);
+
+  @override
+  Future<Result<void>> call(String email) {
+    return _repository
+        .resetPassword(email: email)
+        .then((value) =>
+            Success(null) as Result<void>) // ignore: unnecessary_cast
+        .onError<NetworkExceptions>(
+            (err, stackTrace) => Failed(UseCaseException(err)));
+  }
+}

--- a/test/api/repository/oauth_repository_test.dart
+++ b/test/api/repository/oauth_repository_test.dart
@@ -108,5 +108,22 @@ void main() {
           () => oauthRepository.refreshToken(refreshToken: 'refreshToken');
       expect(result, throwsA(isA<NetworkExceptions>()));
     });
+
+    test('When calling reset password successfully, it returns empty result',
+        () async {
+      when(mockOAuthService.resetPassword(any)).thenAnswer((_) async => null);
+
+      await oauthRepository.resetPassword(email: 'email');
+    });
+
+    test(
+        'When calling reset password failed, it returns NetworkExceptions error',
+        () async {
+      when(mockOAuthService.resetPassword(any)).thenThrow(MockDioError());
+
+      final result = () => oauthRepository.resetPassword(email: 'email');
+
+      expect(result, throwsA(isA<NetworkExceptions>()));
+    });
   });
 }

--- a/test/usecase/reset_password_use_case_test.dart
+++ b/test/usecase/reset_password_use_case_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_survey/api/exception/network_exceptions.dart';
+import 'package:flutter_survey/usecase/base/base_use_case.dart';
+import 'package:flutter_survey/usecase/reset_password_use_case.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+import '../mock/mock_data.mocks.dart';
+
+void main() {
+  group('ResetPasswordUseCaseTest', () {
+    late MockOAuthRepository mockRepository;
+    late ResetPasswordUseCase useCase;
+
+    setUp(() async {
+      mockRepository = MockOAuthRepository();
+
+      useCase = ResetPasswordUseCase(mockRepository);
+    });
+
+    test('When calling API with valid data, it returns Success result',
+        () async {
+      when(mockRepository.resetPassword(email: anyNamed('email')))
+          .thenAnswer((_) async => null);
+      final result = await useCase.call('email');
+
+      expect(result, isA<Success>());
+    });
+
+    test('When calling API with invalid data, it returns Failed result',
+        () async {
+      when(mockRepository.resetPassword(email: anyNamed('email')))
+          .thenAnswer((_) => Future.error(
+                NetworkExceptions.unauthorisedRequest(),
+              ));
+      final result = await useCase.call('email');
+
+      expect(result, isA<Failed>());
+      expect((result as Failed).exception.actualException,
+          NetworkExceptions.unauthorisedRequest());
+    });
+  });
+}


### PR DESCRIPTION
https://github.com/luongvo/flutter-survey/issues/9

## What happened 👀

-  Implement backend components of reset password API `POST `/api/v1/passwords`

## Insight 📝

N/A
 
## Proof Of Work 📹

```
I/flutter (32212): *** Request ***
I/flutter (32212): uri: https://survey-api.nimblehq.co/api/v1/passwords
I/flutter (32212): method: POST
I/flutter (32212): responseType: ResponseType.json
I/flutter (32212): followRedirects: true
I/flutter (32212): connectTimeout: 3000
I/flutter (32212): sendTimeout: 0
I/flutter (32212): receiveTimeout: 5000
I/flutter (32212): receiveDataWhenStatusError: true
I/flutter (32212): extra: {}
I/flutter (32212): headers:
I/flutter (32212):  content-type: application/json; charset=utf-8
I/flutter (32212): data:
I/flutter (32212): {user: Instance of 'UserRequest', client_id: 6GbE8dhoz519l2N_F99StqoOs6Tcmm1rXgda4q__rIw, client_secret: _ayfIm7BeUAhx2W1OUqi20fwO3uNxfo1QstyKlFCgHw}
I/flutter (32212): 
I/flutter (32212): *** Response ***
I/flutter (32212): uri: https://survey-api.nimblehq.co/api/v1/passwords
I/flutter (32212): statusCode: 200
I/flutter (32212): headers:
I/flutter (32212):  connection: keep-alive
I/flutter (32212):  cache-control: max-age=0, private, must-revalidate
I/flutter (32212):  transfer-encoding: chunked
I/flutter (32212):  date: Sun, 11 Sep 2022 11:37:54 GMT
I/flutter (32212):  vary: Accept-Encoding, Origin
I/flutter (32212):  content-encoding: gzip
I/flutter (32212):  strict-transport-security: max-age=31536000; includeSubDomains
I/flutter (32212):  referrer-policy: strict-origin-when-cross-origin
I/flutter (32212):  report-to: {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=qfqC3F6Qts0RzNyqjK79Kti1z0w9dsZt883vOUmuUBapApKh0XXJ69JdvEcZp1yC5r6ABDYsuiAdV5mvlsOSHnsfAx3reCLeLZUEIQ9xFPn9bCn3WWGbtPrJ6fvfPOkEhzkkZf4iUspam1GpInCOrFSBQjYz"}],"group":"cf-nel","max_age":604800}
I/flutter (32212):  cf-cache-status: DYNAMIC
I/flutter (32212):  x-permitted-cross-domain-policies: none
I/flutter (32212):  content-type: application/json; charset=utf-8
I/flutter (32212):  x-xss-protection: 1; mode=block
I/flutter (32212):  server: cloudflare
I/flutter (32212):  x-request-id: 7c6af8b9-5b4e-4663-8727-935a1c182101
I/flutter (32212):  alt-svc: h3=":443"; ma=86400, h3-29=":443"; ma=86400
I/flutter (32212):  nel: {"success_fraction":0,"report_to":"cf-nel","max_age":604800}
I/flutter (32212):  x-download-options: noopen
I/flutter (32212):  cf-ray: 74901d2e0c58b425-HKG
I/flutter (32212):  x-runtime: 0.393341
I/flutter (32212):  etag: W/"06add6e46425ec1d2678fea245167985"
I/flutter (32212):  via: 1.1 vegur
I/flutter (32212):  x-frame-options: SAMEORIGIN
I/flutter (32212):  x-content-type-options: nosniff
I/flutter (32212): Response Text:
I/flutter (32212): {"meta":{"message":"If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."}}
I/flutter (32212): 
E/flutter (32212): [ERROR:flutter/lib/ui/ui_dart_state.cc(209)] Unhandled Exception: Bad state: Tried to use ResetPasswordViewModel after `dispose` was called.
```